### PR TITLE
Add userdebug to menu

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace tool_userdebug;
+use core_user\hook\extend_user_menu;
+
 
 /**
  * Callbacks for hooks.
@@ -38,5 +40,16 @@ class hook_callbacks {
         }
 
         \tool_userdebug\util::setdebug();
+    }
+
+    /**
+     * This is the hook enables the plugin to add one or more menu item.
+     *
+     * @param extend_user_menu $hook
+     */
+    public static function extend_user_menu(extend_user_menu $hook): void {
+        global $CFG;
+        $navitems = util::add_menuuser();
+        $hook->add_navitem($navitems);
     }
 }

--- a/classes/util.php
+++ b/classes/util.php
@@ -16,6 +16,12 @@
 
 namespace tool_userdebug;
 
+
+use action_link;
+use moodle_url;
+use popup_action;
+use stdClass;
+
 /**
  * Utility class to manage the user defined debuging mode.
  *
@@ -224,6 +230,24 @@ class util {
         $content->url = $navigationnode->action;
         $content->icon = $OUTPUT->render($navigationnode->icon);
         return $OUTPUT->render_from_template('tool_userdebug/navbar_action', $content);
+    }
+
+    /**
+     * Add an item in the navigation menu.
+     *
+     * @return stdClass The navigation item.
+     */
+    public static function add_menuuser(): stdClass {
+        if (!$navigationnode = static::get_settings_node()) {
+            return '';
+        }
+
+        $content = new \stdClass();
+        $content->itemtype = 'link';
+        $content->title = $navigationnode->text;
+        $content->url = $navigationnode->action;
+
+        return $content;
     }
 
 }

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -29,4 +29,9 @@ $callbacks = [
         'hook' => \core\hook\after_config::class,
         'callback' => [\tool_userdebug\hook_callbacks::class, 'after_config'],
     ],
+    [
+        'hook' => core_user\hook\extend_user_menu::class,
+        'callback' => '\tool_userdebug\hook_callbacks::extend_user_menu',
+        'priority' => 0,
+    ],
 ];


### PR DESCRIPTION
This refer to #12  and will add the userdebug link to the navigation menu under profile, using the new hook extend_user_menu https://tracker.moodle.org/browse/MDL-71823

