### PR TITLE
Skip on adding usermenu when PHPUNIT is running #17

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -243,6 +243,10 @@ class util {
             return null;
         }
 
+        if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+            return null;
+        }
+
         $content = new \stdClass();
         $content->itemtype = 'link';
         $content->title = $navigationnode->text;


### PR DESCRIPTION
This fix is for #17. Adding an if/else block to skip adding usermenu when running php unit test.